### PR TITLE
Update example for latest mocket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-venv*/
+.venv*/
+.vscode/
 .DS_Store
 *.pyc
 *$py.class

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.venv*/
+venv*/
+.venv/
 .vscode/
 .DS_Store
 *.pyc

--- a/README.md
+++ b/README.md
@@ -7,3 +7,18 @@ Client-Server Toy initially designed for our talk at Europython 2013
 - Neo is your client, basically what we want to test.
 
 Mocket shows its power in the tests file, where you can see the first test using the real server, and a couple of tests using *mocketize* decorator.
+
+Quick Start
+
+```sh
+# Install Dependencies to a local .venv/
+python -m pip install -r requirements.txt
+
+# In separate shells, run the server and the client:
+python morpheus.py
+python neo.py
+
+# One test expects the server (morpheus.py) to be running, while the other two tests demonstrate mocking
+python morpheus.py
+python -m unittest tests.py
+```

--- a/morpheus.py
+++ b/morpheus.py
@@ -1,21 +1,21 @@
 import asyncore
 import socket
 
+from mocket.compat import encode_to_bytes
+
 
 class Morpheus(asyncore.dispatcher_with_send):
-
     def handle_read(self):
         data = self.recv(8192).strip()
-        if data == 'I know kung fu.'.encode('utf8'):
-            reply = 'Show me.'.encode('utf8')
+        if data == encode_to_bytes('I know kung fu.'):
+            reply = encode_to_bytes('Show me.')
         else:
-            reply = 'Blue Pill.'.encode('utf8')
-        self.send(reply + '\r\n'.encode('utf8'))
+            reply = encode_to_bytes('Blue Pill.')
+        self.send(reply + encode_to_bytes('\r\n'))
         self.close()
 
 
 class MorpheusServer(asyncore.dispatcher):
-
     def __init__(self, host, port):
         asyncore.dispatcher.__init__(self)
         self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -31,7 +31,6 @@ class MorpheusServer(asyncore.dispatcher):
 
     def handle_error(self):
         pass
-
 
 if __name__ == '__main__':
     server = MorpheusServer('localhost', 8080)

--- a/morpheus.py
+++ b/morpheus.py
@@ -1,21 +1,21 @@
 import asyncore
 import socket
 
-from mocket.compat import encode_utf8
-
 
 class Morpheus(asyncore.dispatcher_with_send):
+
     def handle_read(self):
         data = self.recv(8192).strip()
-        if data == encode_utf8('I know kung fu.'):
-            reply = encode_utf8('Show me.')
+        if data == 'I know kung fu.'.encode('utf8'):
+            reply = 'Show me.'.encode('utf8')
         else:
-            reply = encode_utf8('Blue Pill.')
-        self.send(reply + encode_utf8('\r\n'))
+            reply = 'Blue Pill.'.encode('utf8')
+        self.send(reply + '\r\n'.encode('utf8'))
         self.close()
 
 
 class MorpheusServer(asyncore.dispatcher):
+
     def __init__(self, host, port):
         asyncore.dispatcher.__init__(self)
         self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -31,6 +31,7 @@ class MorpheusServer(asyncore.dispatcher):
 
     def handle_error(self):
         pass
+
 
 if __name__ == '__main__':
     server = MorpheusServer('localhost', 8080)

--- a/neo.py
+++ b/neo.py
@@ -1,17 +1,15 @@
 import socket
 
-from mocket.compat import encode_utf8
-
-
 class Neo(object):
+
     def __init__(self, addr=None):
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.connect(addr or ('localhost', 8080))
 
     def iknow(self):
         self._fp = self.sock.makefile('rb')
-        self.sock.sendall(encode_utf8('I know kung fu.\r\n'))
-        return self._fp.read().strip() == encode_utf8('Show me.')
+        self.sock.sendall('I know kung fu.\r\n'.encode('utf8'))
+        return self._fp.read().strip() == 'Show me.'.encode('utf8')
 
 
 if __name__ == '__main__':

--- a/neo.py
+++ b/neo.py
@@ -1,15 +1,17 @@
 import socket
 
-class Neo(object):
+from mocket.compat import encode_to_bytes
 
+
+class Neo(object):
     def __init__(self, addr=None):
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.connect(addr or ('localhost', 8080))
 
     def iknow(self):
         self._fp = self.sock.makefile('rb')
-        self.sock.sendall('I know kung fu.\r\n'.encode('utf8'))
-        return self._fp.read().strip() == 'Show me.'.encode('utf8')
+        self.sock.sendall(encode_to_bytes('I know kung fu.\r\n'))
+        return self._fp.read().strip() == encode_to_bytes('Show me.')
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+mocket>=3.9.2
+pytest>=6.1.2
+requests>=2.24.0

--- a/tests.py
+++ b/tests.py
@@ -1,9 +1,13 @@
 from unittest import TestCase
+
 from mocket.mocket import Mocket, MocketEntry, mocketize
+
 from neo import Neo
 
 
+# Note: `morpheus.py` server must be running
 class RealTestCase(TestCase):
+
     def test_ok(self):
         neo = Neo()
         self.assertTrue(neo.iknow())
@@ -11,16 +15,19 @@ class RealTestCase(TestCase):
 
 
 class MockTestCase(TestCase):
+
+    addr = ('localhost', 8080)
+
     @mocketize
     def test_ok(self):
-        Mocket.register(MocketEntry(('localhost', 8080), ['Show me.\r\n']))
-        neo = Neo()
+        Mocket.register(MocketEntry(self.addr, ['Show me.\r\n']))
+        neo = Neo(addr=self.addr)
         self.assertTrue(neo.iknow())
         self.assertEqual(len(Mocket._requests), 1)
 
     @mocketize
     def test_ko(self):
-        Mocket.register(MocketEntry(('localhost', 8080), ['Blue Pill.\r\n']))
-        neo = Neo()
+        Mocket.register(MocketEntry(self.addr, ['Blue Pill.\r\n']))
+        neo = Neo(addr=self.addr)
         self.assertFalse(neo.iknow())
         self.assertEqual(len(Mocket._requests), 1)

--- a/tests.py
+++ b/tests.py
@@ -1,13 +1,9 @@
 from unittest import TestCase
-
 from mocket.mocket import Mocket, MocketEntry, mocketize
-
 from neo import Neo
 
 
-# Note: `morpheus.py` server must be running
 class RealTestCase(TestCase):
-
     def test_ok(self):
         neo = Neo()
         self.assertTrue(neo.iknow())
@@ -15,19 +11,16 @@ class RealTestCase(TestCase):
 
 
 class MockTestCase(TestCase):
-
-    addr = ('localhost', 8080)
-
     @mocketize
     def test_ok(self):
-        Mocket.register(MocketEntry(self.addr, ['Show me.\r\n']))
-        neo = Neo(addr=self.addr)
+        Mocket.register(MocketEntry(('localhost', 8080), ['Show me.\r\n']))
+        neo = Neo()
         self.assertTrue(neo.iknow())
         self.assertEqual(len(Mocket._requests), 1)
 
     @mocketize
     def test_ko(self):
-        Mocket.register(MocketEntry(self.addr, ['Blue Pill.\r\n']))
-        neo = Neo(addr=self.addr)
+        Mocket.register(MocketEntry(('localhost', 8080), ['Blue Pill.\r\n']))
+        neo = Neo()
         self.assertFalse(neo.iknow())
         self.assertEqual(len(Mocket._requests), 1)


### PR DESCRIPTION
I made some minor tweaks to the example to work with Python 3.7. I think there appears to be a regression bug with mocket that I'll submit changes for as a PR

To get this example to work, you would need to use the code on my fork of python-mocket: https://github.com/KyleKing/python-mocket